### PR TITLE
Remove flag because PostgreSQL not installed on macos-latest

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -126,8 +126,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install postgresql@16
-          # --overwrite: Overwrite pre-installed GitHub Actions PostgreSQL binaries
-          brew link --overwrite postgresql@16
+          brew link postgresql@16
       - name: Add PostgreSQL binaries to PATH
         shell: bash
         run: |


### PR DESCRIPTION
Remove `--overwrite` flag because `macos-latest` doesn't contain PostgreSQL since macOS v13:

- macOS 12 (has PostgreSQL) https://github.com/actions/runner-images/blob/macos-12/20240527.4/images/macos/macos-12-Readme.md
- macOS 13 (no PostgreSQL) https://github.com/actions/runner-images/blob/macos-12/20240527.4/images/macos/macos-13-Readme.md

Already found out about this in this PR, but didn't change the `--overwrite` flag:

- https://github.com/karlhorky/github-tricks/pull/1

Tested here:

- https://github.com/upleveled/preflight-test-project-next-js-passing/pull/574